### PR TITLE
不允许修改item的title，可以删除再新增，close #12

### DIFF
--- a/src/pages/item-detail/item-detail.html
+++ b/src/pages/item-detail/item-detail.html
@@ -21,7 +21,7 @@
   <ion-list inset>
     <ion-item>
       <ion-label>Title</ion-label>
-      <ion-input text-right type="text" [(ngModel)]="title"></ion-input>
+      <ion-input text-right type="text" [(ngModel)]="title" [disabled]="true"></ion-input>
     </ion-item>
     <ion-item>
       <ion-label>Type</ion-label>


### PR DESCRIPTION
row是依赖item的tltle来匹配显示value的，如果item的title修改又不更新row的内容，就显示不出row的值了。所以禁止修改item的title，如果要修改只能删除再新增，简单粗暴。后续如果认为必要再新增此功能，修改item的title后，需要修改row的内容。